### PR TITLE
added ability to customise http server port and health-check uri

### DIFF
--- a/src/viooh/mirror/http_server.clj
+++ b/src/viooh/mirror/http_server.clj
@@ -22,11 +22,11 @@
 
 
 
-(defmethod ig/init-key ::server [_ _]
+(defmethod ig/init-key ::server [_ {:keys [server]}]
   (let [handler        (api
-                        (GET "/healthcheck" []
+                        (GET (:healthcheck-uri server "/healthcheck") []
                              (resp/response "Spectrum is green" )))
-        stop-server-fn (httpkit/run-server handler {:port 9090})]
+        stop-server-fn (httpkit/run-server handler server)]
     (log/info "http server started")
     stop-server-fn))
 

--- a/src/viooh/mirror/main.clj
+++ b/src/viooh/mirror/main.clj
@@ -40,6 +40,14 @@
    ;; the group level will be merged in the individual mirror
    ;; definitions.
    ;;
+
+   ;;
+   ;; An HTTP server endpoint is started with an healthcheck endpoint
+   ;; in order to facilitate cluster deployment.
+   ;;
+   :server {:port 9090 :healthcheck-uri "/healthcheck"}
+
+
    ;; The mirror's name and the consumer group will be automatically
    ;; generated using the :group-id-prefix. The consumer-group-id can
    ;; be overridden.
@@ -328,7 +336,7 @@
 
     (start-metrics! cfg)
     (u/log ::app-started :config-change-num (:change-num config-entry))
-    (ig/init {::http-server/server {}
+    (ig/init {::http-server/server cfg
               ::mirror/mirrors cfg})))
 
 


### PR DESCRIPTION
Currently the HTTP server port and the healthcheck uri path are hardcoded,
this PR adds the ability to customise them via configuration entry.

The defaults match the previous values so there is no change required in the config for existing installations.