### PR TITLE
Dependencies update

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,9 @@
                  [com.brunobonacci/mulog               "0.7.1"]
                  [com.brunobonacci/mulog-elasticsearch "0.7.1"]
                  [com.brunobonacci/mulog-kafka         "0.7.1"]
-                 [com.brunobonacci/mulog-cloudwatch    "0.7.1"]]
+                 [com.brunobonacci/mulog-cloudwatch    "0.7.1"]
+                 [com.brunobonacci/mulog-mbean-sampler "0.7.1"]
+                 [com.brunobonacci/mulog-jvm-metrics   "0.7.1"]]
 
   :main viooh.mirror.main
 

--- a/project.clj
+++ b/project.clj
@@ -8,12 +8,12 @@
 
   :repositories [["confluent" {:url "https://packages.confluent.io/maven/"}]]
 
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
 
                  [samsara/trackit-core "0.9.3"]
                  [samsara/trackit-prometheus "0.9.3"]
                  [integrant "0.8.0"]
-                 [http-kit "2.3.0"]
+                 [http-kit "2.5.3"]
                  [cheshire "5.10.0"]
                  [metosin/compojure-api "1.1.13"]
 
@@ -24,20 +24,21 @@
 
                  [com.viooh/kafka-ssl-helper "0.9.0"]
 
-                 [fundingcircle/jackdaw "0.7.1"]
+                 [fundingcircle/jackdaw "0.7.10"]
                  [io.confluent/kafka-schema-registry-client "5.4.1"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
 
                  ;;logging
-                 [org.clojure/tools.logging "1.0.0"]
+                 [org.clojure/tools.logging "1.1.0"]
                  [ch.qos.logback/logback-classic "1.2.3"]
-                 [org.codehaus.janino/janino "3.1.1"] ;; logback configuration conditionals :(
+                 [org.codehaus.janino/janino "3.1.3"] ;; logback configuration conditionals :(
                  [com.internetitem/logback-elasticsearch-appender "1.6"]
 
                  ;; observability
-                 [com.brunobonacci/mulog "0.2.0"]
-                 [com.brunobonacci/mulog-elasticsearch "0.2.0"]
-                 [com.brunobonacci/mulog-kafka "0.2.0"]]
+                 [com.brunobonacci/mulog               "0.7.1"]
+                 [com.brunobonacci/mulog-elasticsearch "0.7.1"]
+                 [com.brunobonacci/mulog-kafka         "0.7.1"]
+                 [com.brunobonacci/mulog-cloudwatch    "0.7.1"]]
 
   :main viooh.mirror.main
 
@@ -45,7 +46,7 @@
 
   :profiles {:uberjar {:aot :all}
              :dev {:jvm-opts ["-D1config.default.backend=fs"]
-                   :dependencies [[midje "1.9.9"]
-                                  [org.clojure/test.check "1.0.0"]
-                                  [criterium "0.4.5"]]
+                   :dependencies [[midje "1.9.10"]
+                                  [org.clojure/test.check "1.1.0"]
+                                  [criterium "0.4.6"]]
                    :plugins      [[lein-midje "3.2.2"]]}})


### PR DESCRIPTION
Bumped the version of many dependencies and added two new μ/log samplers for improved observability.

Please note: Although I believe we should bump the `1config` version as well, to the latest one, I haven't changed that one in this PR since it requires some data migration.

Additionally, also `safely` can be updated to `safely-0.7.0-alpha3` which uses μ/log instead of `samsara/trackit` and we could drop the more primitive tracking in favour of μ/log events.

Please do let me know if you are interested in such PRs