### PR TITLE
Fix SchemaRegistry error: Subject 'XYZ' does not have subject-level compatibility configured; error code: 40408

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ the schemas are automatically created in the destination cluster.
       ;; if necessary you can configure schema-registry auth info.
       ;; :schema-registry-configs
       ;;  {:basic.auth.credentials.source "USER_INFO"
-      ;;  :basic.auth.user.info "<SCHEMA_REG_ACCESS_KEY>:<SCHEMA_REG_SECRET_KEY>"}
+      ;;  :basic.auth.user.info "<SCHEMA_REG_USERNAME>:<SCHEMA_REG_PASSWORD>"}
       }
 
      ;; Now in `:mirrors` you can list all the topics (source/dest) to mirror

--- a/src/viooh/mirror/schema_registry.clj
+++ b/src/viooh/mirror/schema_registry.clj
@@ -72,9 +72,9 @@
   `(try
      ~@body
      (catch RestClientException x#
-       (when-not (or (= 40401 (.getErrorCode x#))
-                     (= 40402 (.getErrorCode x#))
-                     (= 40403 (.getErrorCode x#)))
+       ;; `getErrorCode` returns error codes
+       ;; like: 40401, 40402, 40403, 40408
+       (when-not (= 404 (quot (or (.getErrorCode x#) 0) 100))
          (throw x#)))))
 
 


### PR DESCRIPTION

The SchemaRegistry API on the Confluent platform returns new errors codes (not documented in the API) and unseen before.
The error is returned when attempting to retrieve the subject configuration in order to establish the compatibility level.

If the subject doesn't have a subject-level compatibility configured a error `40408` is returned. see below:

```
"io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException: Subject 'XYZ' does not have subject-level compatibility configured; error code: 40408
    at io.confluent.kafka.schemaregistry.client.rest.RestService.sendHttpRequest(RestService.java:272)
    at io.confluent.kafka.schemaregistry.client.rest.RestService.httpRequest(RestService.java:331)
    at io.confluent.kafka.schemaregistry.client.rest.RestService.getConfig(RestService.java:508)
    at io.confluent.kafka.schemaregistry.client.rest.RestService.getConfig(RestService.java:499)
    at io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient.getCompatibility(CachedSchemaRegistryClient.java:358)
    at viooh.mirror.schema_registry$subject_compatibility$fn__15919.invoke(schema_registry.clj:180)
    at safely.core$make_attempt_direct.invokeStatic(core.clj:257)
    at safely.core$make_attempt_direct.invoke(core.clj:253)
    at safely.core$make_attempt.invokeStatic(core.clj:388)
    at safely.core$make_attempt.invoke(core.clj:382)
    at safely.core$safely_fn$fn__15787.invoke(core.clj:640)
    at safely.core$safely_fn.invokeStatic(core.clj:638)
    at safely.core$safely_fn.doInvoke(core.clj:399)
    at clojure.lang.RestFn.invoke(RestFn.java:1305)
    at viooh.mirror.schema_registry$subject_compatibility.invokeStatic(schema_registry.clj:178)
    at viooh.mirror.schema_registry$subject_compatibility.invoke(schema_registry.clj:172)
    at viooh.mirror.schema_mirror$compare_subjects.invokeStatic(schema_mirror.clj:150)
    at viooh.mirror.schema_mirror$compare_subjects.invoke(schema_mirror.clj:131)
    at viooh.mirror.schema_mirror$analyse_subjects.invokeStatic(schema_mirror.clj:453)
    at viooh.mirror.schema_mirror$analyse_subjects.invoke(schema_mirror.clj:444)
    at viooh.mirror.schema_mirror$mirror_schemas.invokeStatic(schema_mirror.clj:506)
    at viooh.mirror.schema_mirror$mirror_schemas.invoke(schema_mirror.clj:498)
    at viooh.mirror.mirror$mirror$fn__16675$fn__16677.invoke(mirror.clj:235)
    at safely.core$make_attempt_direct.invokeStatic(core.clj:257)
    at safely.core$make_attempt_direct.invoke(core.clj:253)
    at safely.core$make_attempt.invokeStatic(core.clj:388)
    at safely.core$make_attempt.invoke(core.clj:382)
    at safely.core$safely_fn$fn__15787.invoke(core.clj:640)
    at safely.core$safely_fn.invokeStatic(core.clj:638)
    at safely.core$safely_fn.doInvoke(core.clj:399)
    at clojure.lang.RestFn.invoke(RestFn.java:713)
    at viooh.mirror.mirror$mirror$fn__16675.invoke(mirror.clj:228)
    at clojure.core$map$fn__5884.invoke(core.clj:2759)
    at clojure.lang.LazySeq.sval(LazySeq.java:42)
    at clojure.lang.LazySeq.seq(LazySeq.java:51)
    at clojure.lang.RT.seq(RT.java:535)
    at clojure.core$seq__5419.invokeStatic(core.clj:139)
    at clojure.core$dorun.invokeStatic(core.clj:3121)
    at clojure.core$doall.invokeStatic(core.clj:3136)
    at clojure.core$doall.invoke(core.clj:3136)
    at viooh.mirror.mirror$mirror.invokeStatic(mirror.clj:244)
    at viooh.mirror.mirror$mirror.invoke(mirror.clj:210)
    at viooh.mirror.mirror$start_mirror$fn__16684$fn__16685.invoke(mirror.clj:310)
    at safely.core$make_attempt_direct.invokeStatic(core.clj:257)
    at safely.core$make_attempt_direct.invoke(core.clj:253)
    at safely.core$make_attempt.invokeStatic(core.clj:388)
    at safely.core$make_attempt.invoke(core.clj:382)
    at safely.core$safely_fn$fn__15787.invoke(core.clj:640)
    at safely.core$safely_fn.invokeStatic(core.clj:638)
    at safely.core$safely_fn.doInvoke(core.clj:399)
    at clojure.lang.RestFn.invoke(RestFn.java:713)
    at viooh.mirror.mirror$start_mirror$fn__16684.invoke(mirror.clj:297)
    at safely.thread_pool$thread_STAR_$thunk_STAR___14961.invoke(thread_pool.clj:190)
    at clojure.lang.AFn.run(AFn.java:22)
    at java.base/java.lang.Thread.run(Thread.java:831)
```

this patch ensures that new and old error codes are properly interpreted.